### PR TITLE
bug fix: Hacknet uses the wrong word "Immediatley"

### DIFF
--- a/examples/Sequencer_Example.xml
+++ b/examples/Sequencer_Example.xml
@@ -4,7 +4,7 @@
         <StartScreenBleedEffect AlertTitle="Sequencer Attack" CompleteAction="Actions/SequencerFailed.xml" TotalDurationSeconds="135.0" DelayHost="delay" Delay="11.5">Break into node
         Delete stuff
         Get out</StartScreenBleedEffect>
-        <RunFunction FunctionName="playCustomSongImmediately:Music/RollerMobster.ogg"/>
+        <RunFunction FunctionName="playCustomSongImmediatley:Music/RollerMobster.ogg"/>
         <SwitchToThem ThemePathOrName="Themes/SequencerTheme.xml" FlickerInDuration="2.0" DelayHost="delay" Delay="12.0"/>
     </Instantly>
     

--- a/src/Actions.code-snippets
+++ b/src/Actions.code-snippets
@@ -246,7 +246,7 @@
 			"${7:Step 2}",
 			"${8:Step 3}</StartScreenBleedEffect>",
 			"$BLOCK_COMMENT_START Hacknet will do weird formatting if you tab the content of a tag, so best to just not... not tab. BLOCK_COMMENT_END",
-			"\t\t<RunFunction FunctionName=\"playCustomSongImmediately:Music/${9:RollerMobster}.ogg\"/>",
+			"\t\t<RunFunction FunctionName=\"playCustomSongImmediatley:Music/${9:RollerMobster}.ogg\"/>",
 			"\t\t<SwitchToThem ThemePathOrName=\"Themes/${10:SequencerTheme.xml}\" FlickerInDuration=\"${11:2.0}\" DelayHost=\"${12:delayNode}\" Delay=\"${13:12.0}\"/>",
 			"\t</Instantly>",
 			"\t",


### PR DESCRIPTION
The correct spelling of the word is `Immediately`, but Hacknet uses the wrong word `Immediatley` in function `playCustomSongImmediatley`. 